### PR TITLE
Development

### DIFF
--- a/apps/mesh-gov/package-lock.json
+++ b/apps/mesh-gov/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mesh-governance",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mesh-governance",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@geist-ui/core": "^2.3.8",
         "@xyflow/react": "^12.6.0",

--- a/apps/mesh-gov/package.json
+++ b/apps/mesh-gov/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mesh-governance",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
- Bumped the version of the mesh-governance package from 0.2.0 to 0.2.1 in both package.json and package-lock.json to reflect the latest changes and improvements.