### PR TITLE
Development

### DIFF
--- a/apps/cardano-dashboard/scripts/update-drep-metadata.ts
+++ b/apps/cardano-dashboard/scripts/update-drep-metadata.ts
@@ -11,6 +11,7 @@ const RATE_LIMIT_DELAY = 2000; // 2 seconds between requests
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 5000; // 5 seconds before retry
 const METADATA_UPDATE_THRESHOLD_DAYS = 5;
+const TEMPORARY_SKIP_DAYS_CHECK = true; // Temporary flag to bypass the 5-day check
 
 interface DRepMetadata {
     drep_id: string;
@@ -59,6 +60,8 @@ async function fetchWithRetry(url: string, options: RequestInit, retries = MAX_R
 }
 
 function isMetadataUpdateNeeded(lastUpdateDate: string | null): boolean {
+    if (TEMPORARY_SKIP_DAYS_CHECK) return true;
+
     if (!lastUpdateDate) return true;
 
     const lastUpdate = new Date(lastUpdateDate);


### PR DESCRIPTION
- Introduced TEMPORARY_SKIP_DAYS_CHECK flag to allow skipping the 5-day update check for DRep metadata.
- Updated isMetadataUpdateNeeded function to return true when the flag is enabled, facilitating immediate updates.